### PR TITLE
added mime type checking.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .idea
 build
 dist
+venv/*.*
+venv
+__pycache__

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,9 @@ pyparsing==3.1.2
 PySide6==6.7.0
 transformers==4.39.3
 
+python-magic
+python-magic-bin
+
 # PyTorch
 torch==2.2.2; platform_system != "Windows"
 https://download.pytorch.org/whl/cu121/torch-2.2.2%2Bcu121-cp311-cp311-win_amd64.whl; platform_system == "Windows" and python_version == "3.11"


### PR DESCRIPTION
this will cause a slightly slower loading time, but in exchange will shorten the list greatly.

added psd and tga as ignored file types. even though these are images and would be allowed by the mime checking, they do not display in the gui so it is pointless to show them in the list.
this also adds venv and pycache to gitignore so that I can run in the folder without having to purge to push from local.