### PR TITLE
improve loading time

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,8 +24,8 @@ xformers==0.0.25.post1
 
 # InternLM-XComposer2
 auto-gptq==0.7.1; platform_system == "Linux" or platform_system == "Windows"
+numpy==1.26.4
 
 # WD Tagger
 huggingface-hub==0.23.2
-numpy==1.26.4
 onnxruntime==1.18.0

--- a/taggui/auto_captioning/models.py
+++ b/taggui/auto_captioning/models.py
@@ -3,6 +3,7 @@ from utils.enums import CaptionModelType
 MODELS = [
     'internlm/internlm-xcomposer2-vl-7b-4bit',
     'internlm/internlm-xcomposer2-vl-7b',
+    'internlm/internlm-xcomposer2-4khd-7b',
     'THUDM/cogvlm-chat-hf',
     'THUDM/cogagent-vqa-hf',
     'THUDM/cogvlm2-llama3-chat-19B-int4',
@@ -65,5 +66,7 @@ def get_model_type(model_id: str) -> CaptionModelType:
     if 'wd' in lowercase_model_id and 'tagger' in lowercase_model_id:
         return CaptionModelType.WD_TAGGER
     if 'xcomposer2' in lowercase_model_id:
+        if '4khd' in lowercase_model_id:
+            return CaptionModelType.XCOMPOSER2_4KHD
         return CaptionModelType.XCOMPOSER2
     return CaptionModelType.OTHER

--- a/taggui/auto_captioning/prompts.py
+++ b/taggui/auto_captioning/prompts.py
@@ -13,7 +13,8 @@ def get_default_prompt(model_type: CaptionModelType) -> str:
                       CaptionModelType.LLAVA_NEXT_MISTRAL,
                       CaptionModelType.LLAVA_NEXT_VICUNA):
         return 'Describe the image in one sentence.'
-    if model_type == CaptionModelType.XCOMPOSER2:
+    if model_type in (CaptionModelType.XCOMPOSER2,
+                      CaptionModelType.XCOMPOSER2_4KHD):
         return 'Concisely describe the image.'
     return ''
 
@@ -43,7 +44,8 @@ def format_prompt(prompt: str, model_type: CaptionModelType) -> str:
     if model_type in (CaptionModelType.MOONDREAM1,
                       CaptionModelType.MOONDREAM2):
         return f'<image>\n\nQuestion: {prompt}\n\nAnswer:'
-    if model_type == CaptionModelType.XCOMPOSER2:
+    if model_type in (CaptionModelType.XCOMPOSER2,
+                      CaptionModelType.XCOMPOSER2_4KHD):
         return (f'[UNUSED_TOKEN_146]user\n<ImageHere>{prompt}'
                 f'[UNUSED_TOKEN_145]\n[UNUSED_TOKEN_146]assistant\n')
     return prompt
@@ -78,6 +80,7 @@ def postprocess_prompt_and_generated_text(model_type: CaptionModelType,
                         CaptionModelType.MOONDREAM2):
         generated_text = re.sub('END$', '', generated_text)
         generated_text = re.sub('<$', '', generated_text)
-    elif model_type == CaptionModelType.XCOMPOSER2:
+    elif model_type in (CaptionModelType.XCOMPOSER2,
+                        CaptionModelType.XCOMPOSER2_4KHD):
         generated_text = generated_text.split('[UNUSED_TOKEN_145]')[0]
     return prompt, generated_text

--- a/taggui/models/image_list_model.py
+++ b/taggui/models/image_list_model.py
@@ -1,6 +1,5 @@
 import random
 import sys
-from os.path import splitext
 from collections import Counter, deque
 from dataclasses import dataclass
 from enum import Enum
@@ -117,11 +116,12 @@ class ImageListModel(QAbstractListModel):
             if not suffix.startswith('.'):
                 suffix = '.' + suffix
             image_suffixes.append(suffix)
-        image_paths = [path for path in file_paths 
-                       if str(path).lower().endswith(tuple(image_suffixes))]
-        text_file_paths = [path for path in file_paths
-                           if path.suffix == '.txt']
-        txt_strs = {str(path) for path in text_file_paths}
+        image_paths = {path for path in file_paths
+                       if path.suffix.lower() in image_suffixes}
+        # Comparing paths is slow on some systems, so convert the paths to
+        # strings.
+        text_file_path_strings = {str(path) for path in file_paths
+                                  if path.suffix == '.txt'}
         for image_path in image_paths:
             try:
                 dimensions = imagesize.get(image_path)
@@ -146,11 +146,11 @@ class ImageListModel(QAbstractListModel):
                       f'{exception}', file=sys.stderr)
                 dimensions = None
             tags = []
-            text_file_path = splitext(str(image_path))[0] + '.txt'
-            if text_file_path in txt_strs:
+            text_file_path = image_path.with_suffix('.txt')
+            if str(text_file_path) in text_file_path_strings:
                 # `errors='replace'` inserts a replacement marker such as '?'
                 # when there is malformed data.
-                caption = image_path.with_suffix('.txt').read_text(encoding='utf-8',
+                caption = text_file_path.read_text(encoding='utf-8',
                                                    errors='replace')
                 if caption:
                     tags = caption.split(self.tag_separator)

--- a/taggui/utils/enums.py
+++ b/taggui/utils/enums.py
@@ -40,4 +40,5 @@ class CaptionModelType(Enum):
     MOONDREAM2 = auto()
     WD_TAGGER = auto()
     XCOMPOSER2 = auto()
+    XCOMPOSER2_4KHD = auto()
     OTHER = auto()


### PR DESCRIPTION
improve loading time on faster drives by threading file requests rather than sequentially loading.

on my system, I had a folder of 65k images which took an hour to load (sequential reads are a pain) but with this change, it took around 3 minutes because it wasnt waiting on receiving an image before requesting the next.

this will put more pressure on the drive, but its a massive difference in time for large lists