### PR TITLE
keep track of times

### DIFF
--- a/taggui/auto_captioning/captioning_thread.py
+++ b/taggui/auto_captioning/captioning_thread.py
@@ -407,19 +407,26 @@ class CaptioningThread(QThread):
             print('Canceled captioning.')
             return
         self.clear_console_text_edit_requested.emit()
-        captioning_message = ('Generating tags...'
-                              if model_type == CaptionModelType.WD_TAGGER
-                              else f'Captioning... (device: {device})')
-        print(captioning_message)
-        caption_position = self.caption_settings['caption_position']
         selected_image_count = len(self.selected_image_indices)
         are_multiple_images_selected = selected_image_count > 1
-        captioning_start_datetime = datetime.now()
         if are_multiple_images_selected:
+            captioning_start_datetime = datetime.now()
             formatted_captioning_start_datetime = (
                 captioning_start_datetime.strftime('%Y-%m-%d %H:%M:%S'))
-            print(f'Started captioning at '
-                  f'{formatted_captioning_start_datetime}.')
+            if model_type == CaptionModelType.WD_TAGGER:
+                captioning_message = (
+                    f'Generating tags... (start time: '
+                    f'{formatted_captioning_start_datetime})')
+            else:
+                captioning_message = (
+                    f'Captioning... (device: {device}, start time: '
+                    f'{formatted_captioning_start_datetime})')
+        else:
+            captioning_message = ('Generating tags...'
+                                  if model_type == CaptionModelType.WD_TAGGER
+                                  else f'Captioning... (device: {device})')
+        print(captioning_message)
+        caption_position = self.caption_settings['caption_position']
         for i, image_index in enumerate(self.selected_image_indices):
             start_time = perf_counter()
             if self.is_canceled:
@@ -482,7 +489,7 @@ class CaptioningThread(QThread):
             self.caption_generated.emit(image_index, caption, tags)
             if are_multiple_images_selected:
                 self.progress_bar_update_requested.emit(i + 1)
-            if i == 0:
+            if i == 0 and not are_multiple_images_selected:
                 self.clear_console_text_edit_requested.emit()
             if console_output_caption is None:
                 console_output_caption = caption

--- a/taggui/utils/utils.py
+++ b/taggui/utils/utils.py
@@ -39,3 +39,16 @@ def get_confirmation_dialog_reply(title: str, question: str) -> int:
                                            | QMessageBox.StandardButton.Cancel)
     confirmation_dialog.setDefaultButton(QMessageBox.StandardButton.Yes)
     return confirmation_dialog.exec()
+
+def get_pretty_duration(seconds: float) -> str:
+    MIN = 60
+    HOUR = 60 * MIN
+    DAY = 24 * HOUR
+    if seconds < MIN:
+        return f"{seconds:.1f} s"
+    elif seconds < HOUR:
+        return f"{(seconds / MIN):.1f} min"
+    elif seconds < DAY:
+        return f"{(seconds / HOUR):.1f} h"
+    else:
+        return f"{(seconds / DAY):.1f} d"

--- a/taggui/utils/utils.py
+++ b/taggui/utils/utils.py
@@ -39,16 +39,3 @@ def get_confirmation_dialog_reply(title: str, question: str) -> int:
                                            | QMessageBox.StandardButton.Cancel)
     confirmation_dialog.setDefaultButton(QMessageBox.StandardButton.Yes)
     return confirmation_dialog.exec()
-
-def get_pretty_duration(seconds: float) -> str:
-    MIN = 60
-    HOUR = 60 * MIN
-    DAY = 24 * HOUR
-    if seconds < MIN:
-        return f"{seconds:.1f} s"
-    elif seconds < HOUR:
-        return f"{(seconds / MIN):.1f} min"
-    elif seconds < DAY:
-        return f"{(seconds / HOUR):.1f} h"
-    else:
-        return f"{(seconds / DAY):.1f} d"


### PR DESCRIPTION
see #173

keep track of captioning_time, print start time, end time, avg time and duration:

```
print(f"Captioning started at {start_datetime.strftime('%Y-%m-%d %H:%M:%S')}")
...
print(f"\nCaptioning finished in {get_pretty_duration(diff_secs)} (avg: {avg_time:.1f} s/img) at {end_datetime.strftime('%Y-%m-%d %H:%M:%S')}")
```

added get_pretty_duration which prints in highest unit of time

```
    if seconds < MIN:
        return f"{seconds:.1f} s"
    elif seconds < HOUR:
        return f"{(seconds / MIN):.1f} min"
    elif seconds < DAY:
        return f"{(seconds / HOUR):.1f} h"
    else:
        return f"{(seconds / DAY):.1f} d"
```

@jhc13: i don't know why in captioning_thread.py 403 the prints are deleted after the first captioning:
```
        if are_multiple_images_selected:
            print(f"Captioning started at {start_datetime.strftime('%Y-%m-%d %H:%M:%S')}")
        captioning_times = []
        for i, image_index in enumerate(self.selected_image_indices):
            ...
```

@jhc13: how to show average in progress bar? the only solution I found is with some signal-slots and manually setting progressBar.setFormat