### PR TITLE
save captioning in history.jsonl file with settings and selected images

### DIFF
--- a/taggui/utils/settings.py
+++ b/taggui/utils/settings.py
@@ -10,6 +10,8 @@ DEFAULT_SETTINGS = {
     'insert_space_after_tag_separator': True,
     'autocomplete_tags': True,
     'models_directory_path': ''
+    # directory_path: '' # added by main_window.load_directory
+    # more added by auto_captioner.get_caption_settings
 }
 
 


### PR DESCRIPTION
#171

`.jsonl` expect a json object on every line. here is an (formatted) example. actual file is compact:
```
{
    "date": "2024-06-09 18:19:46",
    "settings": {
        "model": "THUDM/cogvlm2-llama3-chat-19B-int4",
        "prompt": "what are the shapes of their faces and bodies? do you notices anything strange on their faces and bodies?",
        "caption_start": "",
        "caption_position": "Insert after last tag",
        "device": "GPU if available",
        "gpu_index": 0,
        "load_in_4_bit": true,
        "remove_tag_separators": false,
        "bad_words": "",
        "forced_words": "",
        "generation_parameters": {
            "min_new_tokens": 1,
            "max_new_tokens": 512,
            "num_beams": 1,
            "length_penalty": 1.0,
            "do_sample": false,
            "temperature": 1.0,
            "top_k": 50,
            "top_p": 1.0,
            "repetition_penalty": 1.0,
            "no_repeat_ngram_size": 3
        },
        "wd_tagger_settings": {
            "show_probabilities": true,
            "min_probability": 0.4,
            "max_tags": 30,
            "tags_to_exclude": ""
        }
    },
    "images": [
        "000000020.jpg",
        "000000020.webp"
    ]
}
```