### PR TITLE
Use GPU for WD tagger models (if available)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,6 +34,7 @@ numpy==1.26.4
 # WD Tagger
 huggingface-hub==0.26.2
 onnxruntime==1.19.2
+onnxruntime-directml==1.19.2; platform_system == "Windows"
 
 # FlashAttention (Florence-2, Phi-3-Vision)
 flash-attn==2.6.3; platform_system == "Linux"

--- a/taggui/auto_captioning/models/wd_tagger.py
+++ b/taggui/auto_captioning/models/wd_tagger.py
@@ -37,7 +37,7 @@ class WdTaggerModel:
         if not tags_path.is_file():
             tags_path = huggingface_hub.hf_hub_download(
                 model_id, filename='selected_tags.csv')
-        self.inference_session = InferenceSession(model_path)
+        self.inference_session = InferenceSession(model_path, providers=['DmlExecutionProvider', 'CUDAExecutionProvider', 'CPUExecutionProvider'])
         self.tags = []
         self.rating_tags_indices = []
         self.general_tags_indices = []


### PR DESCRIPTION
ONNX defaults to using CPU if these GPU support packages are not installed, which is slow.
It needs `onnxruntime-directml` package on windows or `onnxruntime-gpu` on linux

Performance (`SmilingWolf/wd-eva02-large-tagger-v3`)
default (cpu):

> Finished captioning 100 images in 3.1 minutes (1.8 s/image)

with directml:

> Finished captioning 100 images in 19.2 seconds (0.2 s/image)


