### PR TITLE
Modify `directory_path` setting usage to allow for multiple running instances

### DIFF
--- a/taggui/widgets/main_window.py
+++ b/taggui/widgets/main_window.py
@@ -570,6 +570,4 @@ class MainWindow(QMainWindow):
             directory_path = Path(self.settings.value('directory_path',
                                                       type=str))
             if directory_path.is_dir():
-                self.load_directory(
-                    directory_path,
-                    select_index=image_index)
+                self.load_directory(directory_path, select_index=image_index)

--- a/taggui/widgets/main_window.py
+++ b/taggui/widgets/main_window.py
@@ -37,9 +37,9 @@ class MainWindow(QMainWindow):
         super().__init__()
         self.app = app
         self.settings = get_settings()
-        # The current directory_path will be set later in the call to
-        # self.restore()
-        self.directory_path = Path()
+        # The path of the currently loaded directory. This is set later when a
+        # directory is loaded.
+        self.directory_path = None
         image_list_image_width = self.settings.value(
             'image_list_image_width',
             defaultValue=DEFAULT_SETTINGS['image_list_image_width'], type=int)
@@ -227,10 +227,11 @@ class MainWindow(QMainWindow):
 
     @Slot()
     def select_and_load_directory(self):
-        # Use the last loaded directory as the initial directory.
+        initial_directory = (str(self.directory_path)
+                             if self.directory_path else '')
         load_directory_path = QFileDialog.getExistingDirectory(
             parent=self, caption='Select directory to load images from',
-            dir=str(self.directory_path))
+            dir=initial_directory)
         if not load_directory_path:
             return
         self.load_directory(Path(load_directory_path),

--- a/taggui/widgets/main_window.py
+++ b/taggui/widgets/main_window.py
@@ -206,7 +206,8 @@ class MainWindow(QMainWindow):
         central_widget.addWidget(self.image_viewer)
         self.setCentralWidget(central_widget)
 
-    def load_directory(self, path: Path, select_index: int = 0, save_path = False):
+    def load_directory(self, path: Path, select_index: int = 0,
+                       save_path: bool = False):
         self.directory_path = path.resolve()
         if save_path:
             self.settings.setValue('directory_path', str(self.directory_path))

--- a/taggui/widgets/main_window.py
+++ b/taggui/widgets/main_window.py
@@ -207,9 +207,9 @@ class MainWindow(QMainWindow):
         self.setCentralWidget(central_widget)
 
     def load_directory(self, path: Path, select_index: int = 0,
-                       save_path: bool = False):
+                       save_path_to_settings: bool = False):
         self.directory_path = path.resolve()
-        if save_path:
+        if save_path_to_settings:
             self.settings.setValue('directory_path', str(self.directory_path))
         self.setWindowTitle(path.name)
         self.image_list_model.load_directory(path)
@@ -233,7 +233,8 @@ class MainWindow(QMainWindow):
             dir=str(self.directory_path))
         if not load_directory_path:
             return
-        self.load_directory(Path(load_directory_path), save_path=True)
+        self.load_directory(Path(load_directory_path),
+                            save_path_to_settings=True)
 
     @Slot()
     def reload_directory(self):


### PR DESCRIPTION
### Background:
Instances of `TagGUI` modify the `directory_path` setting value anytime they wish to load (or reload) a directory. In the case of loading a new directory, this is done by a call to `select_and_load_directory()`, which prompts a user to select the new directory and then a call to `load_directory()` (if the selected path is valid.) In the case of reloading the current directory, this is done by loading the current `directory_path` setting value and then passing that value into `load_directory()`.

### Issue:
When multiple instances of `TagGUI` are running at the same time, the last instance to call `select_and_load_directory()` will save to the `directory_path` setting, and any other instance that attempts to reload their own current directory will instead load the last-saved value by another instance instead, unintentionally switching directories. This is worsened by many common actions causing `TagGUI` to reload the current directory, such as moving or deleting images.

### Solution:
Change 1: Save the current selected path to the new class property `self.directory_path`, which is read when reloading the current directory instead of the `directory_path` setting. At application start, the `directory_path` setting is written into `self.directory_path` if it is valid.

Change 2: Only modify the settings value for `directory_path` when calling `load_directory()` from the `select_and_load_directory()` path. This is controlled by a new `save_path` `bool` parameter on `load_directory()`. This prevents calls to `reload_directory()` or `load_directory()` from unnecessarily writing their values into the settings value.

Change 3: When saving a new path into the `directory_path` setting value, call `Path.resolve()` to convert the path into an absolute path.