### PR TITLE
Fix WDTagger when non-square's longest size equals `input_dimension`

### DIFF
--- a/taggui/auto_captioning/models/wd_tagger.py
+++ b/taggui/auto_captioning/models/wd_tagger.py
@@ -136,10 +136,10 @@ class WdTagger(AutoCaptioningModel):
                                   .shape)
         if max_dimension != input_dimension:
             input_dimensions = (input_dimension, input_dimension)
-            pil_image = canvas.resize(input_dimensions,
+            canvas = canvas.resize(input_dimensions,
                                       resample=PilImage.Resampling.BICUBIC)
         # Convert the image to a numpy array.
-        image_array = np.array(pil_image, dtype=np.float32)
+        image_array = np.array(canvas, dtype=np.float32)
         # Reverse the order of the color channels.
         image_array = image_array[:, :, ::-1]
         # Add a batch dimension.

--- a/taggui/auto_captioning/models/wd_tagger.py
+++ b/taggui/auto_captioning/models/wd_tagger.py
@@ -137,7 +137,7 @@ class WdTagger(AutoCaptioningModel):
         if max_dimension != input_dimension:
             input_dimensions = (input_dimension, input_dimension)
             canvas = canvas.resize(input_dimensions,
-                                      resample=PilImage.Resampling.BICUBIC)
+                                   resample=PilImage.Resampling.BICUBIC)
         # Convert the image to a numpy array.
         image_array = np.array(canvas, dtype=np.float32)
         # Reverse the order of the color channels.


### PR DESCRIPTION
### Issue:
`pil_image` is not set to the value of `canvas` when the the longest dimension of `pil_image` is equal to `input_dimension`. This is fine if `pil_image` is a square, however if `pil_image` is not a square, this also means that it does not get padded to be `input_dimension`x`input_dimension`.

For example, if your input image is `128x256`, and the input_dimension is `256`, we do not resize `canvas`, leaving `pil_image` at `128x256` (not padded), and the padded `canvas` value is left unused.

### Solution:
Save the result of `canvas.resize()` back to `canvas`, and use `canvas` instead of `pil_image` as the image to convert into a numpy array.