### PR TITLE
Add support for the JoyCaption model

### DIFF
--- a/taggui/auto_captioning/auto_captioning_model.py
+++ b/taggui/auto_captioning/auto_captioning_model.py
@@ -50,7 +50,8 @@ class AutoCaptioningModel:
         self.caption_start = caption_settings['caption_start']
         self.device_setting: CaptionDevice = caption_settings['device']
         self.device: torch.device = self.get_device()
-        self.dtype_argument = ({'dtype': torch.float16}
+        self.dtype = torch.float16
+        self.dtype_argument = ({'dtype': self.dtype}
                                if self.device.type == 'cuda' else {})
         self.load_in_4_bit = caption_settings['load_in_4_bit']
         self.bad_words_string = caption_settings['bad_words']
@@ -90,12 +91,12 @@ class AutoCaptioningModel:
             quantization_config = BitsAndBytesConfig(
                 load_in_4bit=True,
                 bnb_4bit_quant_type='nf4',
-                bnb_4bit_compute_dtype=torch.float16,
+                bnb_4bit_compute_dtype=self.dtype,
                 bnb_4bit_use_double_quant=True
             )
             arguments['quantization_config'] = quantization_config
         elif self.device.type == 'cuda':
-            arguments['torch_dtype'] = torch.float16
+            arguments['torch_dtype'] = self.dtype
         return arguments
 
     def load_model(self, model_load_arguments: dict):

--- a/taggui/auto_captioning/auto_captioning_model.py
+++ b/taggui/auto_captioning/auto_captioning_model.py
@@ -9,6 +9,7 @@ from PIL import Image as PilImage
 from PIL.ImageOps import exif_transpose
 from transformers import (AutoModelForVision2Seq, AutoProcessor,
                           BatchFeature, BitsAndBytesConfig)
+from transformers.utils.import_utils import is_torch_bf16_gpu_available
 
 import auto_captioning.captioning_thread as captioning_thread
 from utils.enums import CaptionDevice
@@ -51,6 +52,9 @@ class AutoCaptioningModel:
         self.caption_start = caption_settings['caption_start']
         self.device_setting: CaptionDevice = caption_settings['device']
         self.device: torch.device = self.get_device()
+        if self.dtype == torch.bfloat16:
+            if self.device.type != 'cuda' or not is_torch_bf16_gpu_available():
+                self.dtype = torch.float16
         self.dtype_argument = ({'dtype': self.dtype}
                                if self.device.type == 'cuda' else {})
         self.load_in_4_bit = caption_settings['load_in_4_bit']

--- a/taggui/auto_captioning/auto_captioning_model.py
+++ b/taggui/auto_captioning/auto_captioning_model.py
@@ -35,6 +35,7 @@ def replace_template_variables(text: str, image: Image) -> str:
 
 
 class AutoCaptioningModel:
+    dtype = torch.float16
     model_load_context_manager = nullcontext()
     transformers_model_class = AutoModelForVision2Seq
     image_mode = 'RGB'
@@ -50,7 +51,6 @@ class AutoCaptioningModel:
         self.caption_start = caption_settings['caption_start']
         self.device_setting: CaptionDevice = caption_settings['device']
         self.device: torch.device = self.get_device()
-        self.dtype = torch.float16
         self.dtype_argument = ({'dtype': self.dtype}
                                if self.device.type == 'cuda' else {})
         self.load_in_4_bit = caption_settings['load_in_4_bit']

--- a/taggui/auto_captioning/models/joycaption.py
+++ b/taggui/auto_captioning/models/joycaption.py
@@ -1,0 +1,82 @@
+import numpy as np
+import torch
+from transformers import LlavaForConditionalGeneration, BatchFeature
+
+from auto_captioning import captioning_thread
+from auto_captioning.auto_captioning_model import AutoCaptioningModel
+from utils.image import Image
+
+
+class JoycaptionLlavaLlama3(AutoCaptioningModel):
+    transformers_model_class = LlavaForConditionalGeneration
+
+    def __init__(self,
+                 captioning_thread_: 'captioning_thread.CaptioningThread',
+                 caption_settings: dict):
+        super().__init__(captioning_thread_, caption_settings)
+
+        self.input_length = None
+        self.dtype = torch.bfloat16
+        self.dtype_argument = ({'dtype': self.dtype}
+                               if self.device.type == 'cuda' else {})
+
+    def get_error_message(self) -> str | None:
+        if self.load_in_4_bit:
+            # The official model does not currently work when loaded
+            # in 4-bit mode.
+            return 'Joycaption cannot currently be loaded in 4-bit.'
+        return super().get_error_message()
+
+    @staticmethod
+    def get_default_prompt() -> str:
+        return 'Write a stable diffusion prompt for this image.'
+
+    def format_prompt(self, prompt: str) -> str:
+        conversation = [
+                {
+                    "role": "system", 
+                    "content": "You are a helpful image captioner.",
+                },
+                {
+                    "role": "user",
+                    "content": prompt.strip(),
+                },
+        ]
+        templated_prompt = self.processor.apply_chat_template(
+            conversation, tokenize=False, add_generation_prompt=True)
+
+        self.caption_start = self.caption_start.strip()
+        if self.caption_start:
+            templated_prompt = templated_prompt + self.caption_start
+
+        return templated_prompt
+
+    def get_additional_generation_parameters(self) -> dict:
+        additional_parameters = super().get_additional_generation_parameters()
+        additional_parameters['use_cache'] = True
+
+        tokenizer = self.get_tokenizer()
+        eos_token_id = (tokenizer('<|eot_id|>', add_special_tokens=False)
+                        .input_ids)[0]
+        additional_parameters['eos_token_id'] = eos_token_id
+
+        return additional_parameters
+
+    def get_input_text(self, image_prompt: str) -> str:
+    	# Do not add caption_start here, we add it in format_prompt().
+        return image_prompt
+
+    def get_model_inputs(self, image_prompt: str,
+                         image: Image) -> BatchFeature | dict | np.ndarray:
+        model_inputs = super().get_model_inputs(image_prompt, image)
+        # Cache our input token length so we can remove that many from the
+        # model's response.
+        self.input_length = model_inputs['input_ids'].shape[1]
+        return model_inputs
+
+    def get_caption_from_generated_tokens(
+            self, generated_token_ids: torch.Tensor, image_prompt: str) -> str:
+        # Remove our prompt from the generated result
+        generated_token_ids = generated_token_ids[:, self.input_length:]
+        return super().get_caption_from_generated_tokens(
+            generated_token_ids, image_prompt)

--- a/taggui/auto_captioning/models/joycaption.py
+++ b/taggui/auto_captioning/models/joycaption.py
@@ -8,6 +8,7 @@ from utils.image import Image
 
 
 class Joycaption(AutoCaptioningModel):
+    dtype = torch.bfloat16
     transformers_model_class = LlavaForConditionalGeneration
 
     def __init__(self,
@@ -16,7 +17,6 @@ class Joycaption(AutoCaptioningModel):
         super().__init__(captioning_thread_, caption_settings)
 
         self.input_length = None
-        self.dtype = torch.bfloat16
         self.dtype_argument = ({'dtype': self.dtype}
                                if self.device.type == 'cuda' else {})
 

--- a/taggui/auto_captioning/models/joycaption.py
+++ b/taggui/auto_captioning/models/joycaption.py
@@ -7,7 +7,7 @@ from auto_captioning.auto_captioning_model import AutoCaptioningModel
 from utils.image import Image
 
 
-class JoycaptionLlavaLlama3(AutoCaptioningModel):
+class Joycaption(AutoCaptioningModel):
     transformers_model_class = LlavaForConditionalGeneration
 
     def __init__(self,

--- a/taggui/auto_captioning/models/joycaption.py
+++ b/taggui/auto_captioning/models/joycaption.py
@@ -15,7 +15,7 @@ class Joycaption(AutoCaptioningModel):
 
     @staticmethod
     def get_default_prompt() -> str:
-        return 'Write a stable diffusion prompt for this image.'
+        return 'Briefly describe the image.'
 
     def format_prompt(self, prompt: str) -> str:
         conversation = [

--- a/taggui/auto_captioning/models/joycaption.py
+++ b/taggui/auto_captioning/models/joycaption.py
@@ -31,27 +31,21 @@ class Joycaption(AutoCaptioningModel):
 
     def format_prompt(self, prompt: str) -> str:
         conversation = [
-                {
-                    "role": "system", 
-                    "content": "You are a helpful image captioner.",
-                },
-                {
-                    "role": "user",
-                    "content": prompt.strip(),
-                },
+            {
+                'role': 'system',
+                'content': 'You are a helpful image captioner.'
+            },
+            {
+                'role': 'user',
+                'content': prompt
+            }
         ]
         templated_prompt = self.processor.apply_chat_template(
             conversation, tokenize=False, add_generation_prompt=True)
-
-        self.caption_start = self.caption_start.strip()
-        if self.caption_start:
-            templated_prompt = templated_prompt + self.caption_start
-
         return templated_prompt
 
     def get_input_text(self, image_prompt: str) -> str:
-    	# Do not add caption_start here, we add it in format_prompt().
-        return image_prompt
+        return image_prompt + self.caption_start
 
     def get_model_inputs(self, image_prompt: str,
                          image: Image) -> BatchFeature | dict | np.ndarray:

--- a/taggui/auto_captioning/models/joycaption.py
+++ b/taggui/auto_captioning/models/joycaption.py
@@ -20,12 +20,10 @@ class Joycaption(AutoCaptioningModel):
         self.dtype_argument = ({'dtype': self.dtype}
                                if self.device.type == 'cuda' else {})
 
-    def get_error_message(self) -> str | None:
+    def get_additional_error_message(self) -> str | None:
         if self.load_in_4_bit:
-            # The official model does not currently work when loaded
-            # in 4-bit mode.
-            return 'Joycaption cannot currently be loaded in 4-bit.'
-        return super().get_error_message()
+            return 'This model cannot be loaded in 4-bit.'
+        return None
 
     @staticmethod
     def get_default_prompt() -> str:

--- a/taggui/auto_captioning/models/joycaption.py
+++ b/taggui/auto_captioning/models/joycaption.py
@@ -51,17 +51,6 @@ class JoycaptionLlavaLlama3(AutoCaptioningModel):
 
         return templated_prompt
 
-    def get_additional_generation_parameters(self) -> dict:
-        additional_parameters = super().get_additional_generation_parameters()
-        additional_parameters['use_cache'] = True
-
-        tokenizer = self.get_tokenizer()
-        eos_token_id = (tokenizer('<|eot_id|>', add_special_tokens=False)
-                        .input_ids)[0]
-        additional_parameters['eos_token_id'] = eos_token_id
-
-        return additional_parameters
-
     def get_input_text(self, image_prompt: str) -> str:
     	# Do not add caption_start here, we add it in format_prompt().
         return image_prompt

--- a/taggui/auto_captioning/models_list.py
+++ b/taggui/auto_captioning/models_list.py
@@ -14,6 +14,7 @@ from auto_captioning.models.wd_tagger import WdTagger
 from auto_captioning.models.xcomposer2 import Xcomposer2, Xcomposer2_4khd
 
 MODELS = [
+    'fancyfeast/llama-joycaption-alpha-two-hf-llava',
     'internlm/internlm-xcomposer2-vl-7b-4bit',
     'internlm/internlm-xcomposer2-vl-7b',
     'internlm/internlm-xcomposer2-vl-1_8b',
@@ -28,7 +29,6 @@ MODELS = [
     'microsoft/Florence-2-base',
     'MiaoshouAI/Florence-2-base-PromptGen',
     'microsoft/Phi-3-vision-128k-instruct',
-    'fancyfeast/llama-joycaption-alpha-two-hf-llava',
     'llava-hf/llava-v1.6-mistral-7b-hf',
     'llava-hf/llava-v1.6-vicuna-7b-hf',
     'llava-hf/llava-v1.6-vicuna-13b-hf',

--- a/taggui/auto_captioning/models_list.py
+++ b/taggui/auto_captioning/models_list.py
@@ -2,6 +2,7 @@ from auto_captioning.auto_captioning_model import AutoCaptioningModel
 from auto_captioning.models.cog import Cogagent, Cogvlm
 from auto_captioning.models.cogvlm2 import Cogvlm2
 from auto_captioning.models.florence_2 import Florence2, Florence2Promptgen
+from auto_captioning.models.joycaption import JoycaptionLlavaLlama3
 from auto_captioning.models.kosmos_2 import Kosmos2
 from auto_captioning.models.llava_1_point_5 import Llava1Point5
 from auto_captioning.models.llava_llama_3 import LlavaLlama3
@@ -27,6 +28,7 @@ MODELS = [
     'microsoft/Florence-2-base',
     'MiaoshouAI/Florence-2-base-PromptGen',
     'microsoft/Phi-3-vision-128k-instruct',
+    'fancyfeast/llama-joycaption-alpha-two-hf-llava',
     'llava-hf/llava-v1.6-mistral-7b-hf',
     'llava-hf/llava-v1.6-vicuna-7b-hf',
     'llava-hf/llava-v1.6-vicuna-13b-hf',
@@ -74,6 +76,8 @@ def get_model_class(model_id: str) -> type[AutoCaptioningModel]:
         return Florence2
     if 'kosmos' in lowercase_model_id:
         return Kosmos2
+    if 'joycaption' in lowercase_model_id:
+        return JoycaptionLlavaLlama3
     if 'llava-v1.6-34b' in lowercase_model_id:
         return LlavaNext34b
     if 'llava-v1.6-mistral' in lowercase_model_id:

--- a/taggui/auto_captioning/models_list.py
+++ b/taggui/auto_captioning/models_list.py
@@ -2,7 +2,7 @@ from auto_captioning.auto_captioning_model import AutoCaptioningModel
 from auto_captioning.models.cog import Cogagent, Cogvlm
 from auto_captioning.models.cogvlm2 import Cogvlm2
 from auto_captioning.models.florence_2 import Florence2, Florence2Promptgen
-from auto_captioning.models.joycaption import JoycaptionLlavaLlama3
+from auto_captioning.models.joycaption import Joycaption
 from auto_captioning.models.kosmos_2 import Kosmos2
 from auto_captioning.models.llava_1_point_5 import Llava1Point5
 from auto_captioning.models.llava_llama_3 import LlavaLlama3

--- a/taggui/auto_captioning/models_list.py
+++ b/taggui/auto_captioning/models_list.py
@@ -74,10 +74,10 @@ def get_model_class(model_id: str) -> type[AutoCaptioningModel]:
         if 'promptgen' in lowercase_model_id:
             return Florence2Promptgen
         return Florence2
+    if 'joycaption' in lowercase_model_id:
+        return Joycaption
     if 'kosmos' in lowercase_model_id:
         return Kosmos2
-    if 'joycaption' in lowercase_model_id:
-        return JoycaptionLlavaLlama3
     if 'llava-v1.6-34b' in lowercase_model_id:
         return LlavaNext34b
     if 'llava-v1.6-mistral' in lowercase_model_id:


### PR DESCRIPTION
This change errs on the side of following the example implementation from the official Github in regards to model configuration/options.

Addresses #263

### Changes:
Adds support for JoyCaption using the newly processor. This model can be used to caption many types of images in a variety of styles, such as natural language, Booru tags, and more.

Moves usages of `torch.float16` to a class property `dtype` to allow for this type to be overridden. The documentation states that JoyCaption natively uses bfloat16 and I did not investigate if using float16 works.

### Reference:
JoyCaption project github: https://github.com/fpgaminer/joycaption.