### PR TITLE
Add additional WD Tagger generation options

### DIFF
--- a/taggui/auto_captioning/models/wd_tagger.py
+++ b/taggui/auto_captioning/models/wd_tagger.py
@@ -83,7 +83,7 @@ class WdTaggerModel:
                     or tag in tags_to_exclude):
                 continue
             elif (index in self.character_tags_indices
-                and rounded_probability < min_char_probability):
+                    and rounded_probability < min_char_probability):
                 continue
             tags_and_probabilities.append((tag, probability))
         # Sort tags.

--- a/taggui/auto_captioning/models/wd_tagger.py
+++ b/taggui/auto_captioning/models/wd_tagger.py
@@ -13,6 +13,7 @@ from onnxruntime import InferenceSession
 import auto_captioning.captioning_thread as captioning_thread
 from auto_captioning.auto_captioning_model import AutoCaptioningModel
 from utils.image import Image
+from utils.enums import GeneratedTagOrder
 
 KAOMOJIS = ['0_0', '(o)_(o)', '+_+', '+_-', '._.', '<o>_<o>', '<|>_<|>', '=_=',
             '>_<', '3_3', '6_9', '>_o', '@_@', '^_^', 'o_o', 'u_u', 'x_x',
@@ -39,23 +40,25 @@ class WdTaggerModel:
                 model_id, filename='selected_tags.csv')
         self.inference_session = InferenceSession(model_path)
         self.tags = []
-        self.rating_tags_indices = []
-        self.general_tags_indices = []
-        self.character_tags_indices = []
+        self.rating_tags_indices = set()
+        self.general_tags_indices = set()
+        self.character_tags_indices = set()
         with open(tags_path, 'r') as tags_file:
             reader = csv.DictReader(tags_file)
             for index, line in enumerate(reader):
                 tag = line['name']
                 if tag not in KAOMOJIS:
                     tag = tag.replace('_', ' ')
-                self.tags.append(tag)
                 category = line['category']
                 if category == '9':
-                    self.rating_tags_indices.append(index)
+                    # Exclude the rating tags.
+                    self.rating_tags_indices.add(index)
                 elif category == '0':
-                    self.general_tags_indices.append(index)
+                    self.tags.append(tag)
+                    self.general_tags_indices.add(index)
                 elif category == '4':
-                    self.character_tags_indices.append(index)
+                    self.tags.append(tag)
+                    self.character_tags_indices.add(index)
 
     def generate_tags(self, image_array: np.ndarray,
                       wd_tagger_settings: dict) -> tuple[tuple, tuple]:
@@ -63,9 +66,6 @@ class WdTaggerModel:
         output_name = self.inference_session.get_outputs()[0].name
         probabilities = self.inference_session.run(
             [output_name], {input_name: image_array})[0][0].astype(np.float32)
-        # Exclude the rating tags.
-        tags = [tag for index, tag in enumerate(self.tags)
-                if index not in self.rating_tags_indices]
         probabilities = np.array([
             probability for index, probability in enumerate(probabilities)
             if index not in self.rating_tags_indices
@@ -73,13 +73,26 @@ class WdTaggerModel:
         tags_to_exclude = get_tags_to_exclude(
             wd_tagger_settings['tags_to_exclude'])
         tags_and_probabilities = []
-        for tag, probability in zip(tags, probabilities):
-            if (probability < wd_tagger_settings['min_probability']
+        min_probability = wd_tagger_settings['min_probability']
+        min_char_probability = wd_tagger_settings['min_char_probability']
+        for tag_and_index, probability in zip(enumerate(self.tags),
+                                              probabilities):
+            index, tag = tag_and_index
+            rounded_probability = round(probability, 2)
+            if (rounded_probability < min_probability
                     or tag in tags_to_exclude):
                 continue
+            elif (index in self.character_tags_indices
+                and rounded_probability < min_char_probability):
+                continue
             tags_and_probabilities.append((tag, probability))
-        # Sort the tags by probability.
-        tags_and_probabilities.sort(key=lambda x: x[1], reverse=True)
+        # Sort tags.
+        tag_order = wd_tagger_settings['generated_tag_order']
+        if tag_order == GeneratedTagOrder.PROBABILITY:
+            tags_and_probabilities.sort(key=lambda x: x[1], reverse=True)
+        elif tag_order == GeneratedTagOrder.ALPHABETICAL:
+            tags_and_probabilities.sort(key=lambda x: x[0].lower(), reverse=False)
+
         tags_and_probabilities = tags_and_probabilities[
                                  :wd_tagger_settings['max_tags']]
         if tags_and_probabilities:

--- a/taggui/utils/enums.py
+++ b/taggui/utils/enums.py
@@ -24,3 +24,9 @@ class CaptionPosition(str, Enum):
 class CaptionDevice(str, Enum):
     GPU = 'GPU if available'
     CPU = 'CPU'
+
+
+class GeneratedTagOrder(str, Enum):
+    PROBABILITY = 'Highest Probability'
+    ALPHABETICAL = 'Alphabetical'
+    MODEL_DEFAULT = 'Unsorted (Model Default)'

--- a/taggui/widgets/auto_captioner.py
+++ b/taggui/widgets/auto_captioner.py
@@ -14,7 +14,7 @@ from auto_captioning.models_list import MODELS, get_model_class
 from dialogs.caption_multiple_images_dialog import CaptionMultipleImagesDialog
 from models.image_list_model import ImageListModel
 from utils.big_widgets import TallPushButton
-from utils.enums import CaptionDevice, CaptionPosition
+from utils.enums import CaptionDevice, CaptionPosition, GeneratedTagOrder
 from utils.settings import DEFAULT_SETTINGS, get_settings, get_tag_separator
 from utils.settings_widgets import (FocusedScrollSettingsComboBox,
                                     FocusedScrollSettingsDoubleSpinBox,
@@ -122,8 +122,16 @@ class CaptionSettingsForm(QVBoxLayout):
             key='wd_tagger_min_probability', default=0.4, minimum=0.01,
             maximum=1)
         self.min_probability_spin_box.setSingleStep(0.01)
+        self.min_char_probability_spin_box = FocusedScrollSettingsDoubleSpinBox(
+                key='wd_tagger_min_character_probability', default=0.51,
+                minimum=0.01, maximum=1.01)
+        self.min_char_probability_spin_box.setSingleStep(0.01)
         self.max_tags_spin_box = FocusedScrollSettingsSpinBox(
             key='wd_tagger_max_tags', default=30, minimum=1, maximum=999)
+        self.generated_tag_order = FocusedScrollSettingsComboBox(
+            key='wd_tagger_generated_tag_order', 
+        )
+        self.generated_tag_order.addItems(list(GeneratedTagOrder))
         tags_to_exclude_form = QFormLayout()
         tags_to_exclude_form.setRowWrapPolicy(
             QFormLayout.RowWrapPolicy.WrapAllRows)
@@ -136,9 +144,13 @@ class CaptionSettingsForm(QVBoxLayout):
         set_text_edit_height(self.tags_to_exclude_text_edit, 4)
         wd_tagger_settings_form.addRow('Show probabilities',
                                        self.show_probabilities_check_box)
-        wd_tagger_settings_form.addRow('Minimum probability',
+        wd_tagger_settings_form.addRow('Minimum tag probability',
                                        self.min_probability_spin_box)
+        wd_tagger_settings_form.addRow('Minimum character tag probability',
+                                       self.min_char_probability_spin_box)
         wd_tagger_settings_form.addRow('Maximum tags', self.max_tags_spin_box)
+        wd_tagger_settings_form.addRow('Generated Tag Order',
+                                       self.generated_tag_order)
         wd_tagger_settings_form.addRow(tags_to_exclude_form)
 
         self.toggle_advanced_settings_form_button = TallPushButton(
@@ -336,9 +348,13 @@ class CaptionSettingsForm(QVBoxLayout):
                 'show_probabilities':
                     self.show_probabilities_check_box.isChecked(),
                 'min_probability': self.min_probability_spin_box.value(),
+                'min_char_probability':
+                    self.min_char_probability_spin_box.value(),
                 'max_tags': self.max_tags_spin_box.value(),
                 'tags_to_exclude':
-                    self.tags_to_exclude_text_edit.toPlainText()
+                    self.tags_to_exclude_text_edit.toPlainText(),
+                'generated_tag_order':
+                    self.generated_tag_order.currentText()
             }
         }
 


### PR DESCRIPTION
### New
Added support for a minimum character-tag probability. If a character tag's probability is less than this value, it will be discarded. Set to `1.01` to disable character tags. Set to `0.01` to accept any matched character tags. Note: the existing 'Minimum tag probability' must _also_ be met for a tag to be included in results.

Added additional generated-tag sorting option. Generated tags may now be sorted by:
- `Highest probability` -- The existing behavior.
- `Alphabetical` -- the (lowercased) alphabetical order of the tag names.
- `Unsorted (Model Default)` -- tags are left in the order the model generated them. The order of this is model-dependant.

### Changes to existing behavior
Tag categories indexes (general, character, rating) are now stored as sets instead of lists for faster lookup performance. This change slightly increases the RAM footprint, but does not affect VRAM.

Instead of rating-category tags being removed from the tag list for each generation, rating-category tags are no longer added to the overall tag list.

### Bug fix
Tag probability is now rounded to `2` decimal points when determining if a tag passes the minimum probability values. This fixes an issue where a tag's displayed probability could be `0.01` lower than the minimum probability.