### PR TITLE
Add support for 4bit JoyCaption

### DIFF
--- a/taggui/auto_captioning/auto_captioning_model.py
+++ b/taggui/auto_captioning/auto_captioning_model.py
@@ -102,10 +102,11 @@ class AutoCaptioningModel:
                 load_in_4bit=True,
                 bnb_4bit_quant_type='nf4',
                 bnb_4bit_compute_dtype=self.dtype,
+                bnb_4bit_quant_storage=self.dtype,
                 bnb_4bit_use_double_quant=True
             )
             arguments['quantization_config'] = quantization_config
-        elif self.device.type == 'cuda':
+        if self.device.type == 'cuda':
             arguments['torch_dtype'] = self.dtype
         return arguments
 

--- a/taggui/auto_captioning/models/joycaption.py
+++ b/taggui/auto_captioning/models/joycaption.py
@@ -12,9 +12,9 @@ class Joycaption(AutoCaptioningModel):
     def monkey_patch_after_loading(self) -> None:
         if self.load_in_4_bit:
             attention = self.model.vision_tower.vision_model.head.attention
-            # If our out_proj was converted into a nn.Linear4bit, replace
-            # it with the original nn.Linear. JoyCaption's out-projection
-            # layer is not dynamically quantizable.
+            # JoyCaption's out-projection layer is not dynamically quantizable,
+            # so if it was converted into `nn.Linear4bit`, replace it with the
+            # original `nn.Linear`.
             if isinstance(attention.out_proj, bitsandbytes.nn.Linear4bit):
                 attention.out_proj = torch.nn.Linear(
                     in_features=attention.embed_dim,

--- a/taggui/auto_captioning/models/joycaption.py
+++ b/taggui/auto_captioning/models/joycaption.py
@@ -1,3 +1,4 @@
+import bitsandbytes
 import torch
 from transformers import LlavaForConditionalGeneration
 
@@ -8,10 +9,18 @@ class Joycaption(AutoCaptioningModel):
     dtype = torch.bfloat16
     transformers_model_class = LlavaForConditionalGeneration
 
-    def get_additional_error_message(self) -> str | None:
+    def monkey_patch_after_loading(self) -> None:
         if self.load_in_4_bit:
-            return 'This model cannot be loaded in 4-bit.'
-        return None
+            attention = self.model.vision_tower.vision_model.head.attention
+            # If our out_proj was converted into a nn.Linear4bit, replace
+            # it with the original nn.Linear. JoyCaption's out-projection
+            # layer is not dynamically quantizable.
+            if isinstance(attention.out_proj, bitsandbytes.nn.Linear4bit):
+                attention.out_proj = torch.nn.Linear(
+                    in_features=attention.embed_dim,
+                    out_features=attention.embed_dim,
+                    device=self.device,
+                    dtype=self.dtype)
 
     @staticmethod
     def get_default_prompt() -> str:


### PR DESCRIPTION
tl;dr: bitsandbytes is quantizing a `nn.NonDynamicallyQuantizableLinear` output in JoyCaption.  We revert it back to a `nn.Linear` (as `nn.NonDynamicallyQuantizableLinear` is not a constructable type.)

We also set the dtype in a few more places where we don't, or don't always.